### PR TITLE
Allow php7.2

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -18,7 +18,7 @@
 	<bugs>https://github.com/ChristophWurst/nextcloud_sentry/issues</bugs>
 	<repository>https://github.com/ChristophWurst/nextcloud_sentry</repository>
 	<dependencies>
-		<php min-version="5.6" max-version="7.1" />
+		<php min-version="5.6" max-version="7.2" />
 		<nextcloud min-version="13" max-version="13" />
 	</dependencies>
 </info>


### PR DESCRIPTION
php7.2 has landed on Arch and nc complained about it right away.