### PR TITLE
Fix composer package definition - this is not a lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
 	"name": "christophwurst/nextcloud_sentry",
-	"type": "library",
 	"license": "AGPL-3.0",
 	"authors": [
 		{


### PR DESCRIPTION
This is required for dependabot which doesn't support libs at the moment.