### PR TITLE
Get correct level of breadcrumb

### DIFF
--- a/lib/Reporter/SentryReporterAdapter.php
+++ b/lib/Reporter/SentryReporterAdapter.php
@@ -118,7 +118,7 @@ class SentryReporterAdapter implements IReporter, ICollectBreadcrumbs {
 	public function collect(string $message, string $category, array $context = []) {
 		$this->setSentryScope($context);
 
-		$level = isset($context['level']);
+		$level = $context['level'] ?? ILogger::WARN;
 		$sentryLevel = $this->levels[$level] ?? Breadcrumb::LEVEL_WARNING;
 
 		addBreadcrumb(new Breadcrumb($sentryLevel, Breadcrumb::TYPE_ERROR, $category, $message));


### PR DESCRIPTION
Before this change, the level was always INFO

Fixes https://github.com/ChristophWurst/nextcloud_sentry/issues/114