### PR TITLE
Fix recursive reports

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Sentry\AppInfo;
 
+use OCA\Sentry\Reporter\RecursionAwareReporter;
 use OCA\Sentry\Reporter\SentryReporterAdapter;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
@@ -77,7 +78,7 @@ class Application extends App {
 		/* @var $registry IRegistry */
 		$registry = $container->query(IRegistry::class);
 		$reporter = $container->query(SentryReporterAdapter::class);
-		$registry->register($reporter);
+		$registry->register(new RecursionAwareReporter($reporter));
 	}
 
 	private function createCsp(?string $publicDsn, ?string $reportUrl): ContentSecurityPolicy {

--- a/lib/Reporter/RecursionAwareReporter.php
+++ b/lib/Reporter/RecursionAwareReporter.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Sentry\Reporter;
+
+use OCP\Support\CrashReport\ICollectBreadcrumbs;
+use OCP\Support\CrashReport\IMessageReporter;
+use OCP\Support\CrashReport\IReporter;
+
+/**
+ * Decorator that detects and stops recursive calls to reporter methods
+ */
+class RecursionAwareReporter implements IMessageReporter, ICollectBreadcrumbs {
+
+	/** @var IReporter */
+	private $reporter;
+
+	private $reporting = false;
+
+	public function __construct(IReporter $reporter) {
+		$this->reporter = $reporter;
+	}
+
+	private function guard(callable $run): void {
+		try {
+			if ($this->reporting) {
+				// Break the recursion
+				return;
+			}
+			$this->reporting = true;
+			$run();
+		} finally {
+			$this->reporting = false;
+		}
+	}
+
+	public function collect(string $message, string $category, array $context = []): void {
+		if ($this->reporter instanceof ICollectBreadcrumbs) {
+			$this->guard(function() use ($context, $category, $message) {
+				$this->reporter->collect($message, $category, $context);
+			});
+		}
+	}
+
+	public function reportMessage(string $message, array $context = []): void {
+		if ($this->reporter instanceof IMessageReporter) {
+			$this->guard(function() use ($context, $message) {
+				$this->reporter->reportMessage($message, $context);
+			});
+		}
+	}
+
+	public function report($exception, array $context = []): void {
+		$this->guard(function() use ($context, $exception) {
+			$this->reporter->report($exception, $context);
+		});
+	}
+
+}

--- a/lib/Reporter/SentryReporterAdapter.php
+++ b/lib/Reporter/SentryReporterAdapter.php
@@ -50,7 +50,7 @@ class SentryReporterAdapter implements IMessageReporter, ICollectBreadcrumbs {
 	private $credentialStoreHelper;
 
 	/** @var array mapping of log levels */
-	protected $levels = [
+	private const levels = [
 		ILogger::DEBUG => Severity::DEBUG,
 		ILogger::INFO => Severity::INFO,
 		ILogger::WARN => Severity::WARNING,
@@ -59,7 +59,7 @@ class SentryReporterAdapter implements IMessageReporter, ICollectBreadcrumbs {
 	];
 
 	/** @var int */
-	protected $minimumLogLevel;
+	private $minimumLogLevel;
 
 	public function __construct(IUserSession $userSession,
 								IConfig $config,
@@ -91,7 +91,7 @@ class SentryReporterAdapter implements IMessageReporter, ICollectBreadcrumbs {
 		configureScope(function (Scope $scope) use ($context): void {
 			if (isset($context['level'])) {
 				$scope->setLevel(
-					new Severity($this->levels[$context['level']])
+					new Severity(self::levels[$context['level']])
 				);
 			}
 			if (isset($context['app'])) {
@@ -124,7 +124,7 @@ class SentryReporterAdapter implements IMessageReporter, ICollectBreadcrumbs {
 		$this->setSentryScope($context);
 
 		$level = $context['level'] ?? ILogger::WARN;
-		$sentryLevel = $this->levels[$level] ?? Breadcrumb::LEVEL_WARNING;
+		$sentryLevel = self::levels[$level] ?? Breadcrumb::LEVEL_WARNING;
 
 		addBreadcrumb(new Breadcrumb($sentryLevel, Breadcrumb::TYPE_ERROR, $category, $message));
 	}
@@ -148,7 +148,7 @@ class SentryReporterAdapter implements IMessageReporter, ICollectBreadcrumbs {
 
 		captureMessage(
 			$message,
-			new Severity($this->levels[$context['level'] ?? ILogger::WARN] ?? Severity::WARNING)
+			new Severity(self::levels[$context['level'] ?? ILogger::WARN] ?? Severity::WARNING)
 		);
 	}
 

--- a/tests/Unit/Reporter/RecursionAwareReporterTest.php
+++ b/tests/Unit/Reporter/RecursionAwareReporterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Sentry\Test\Unit\Reporter;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use Exception;
+use OCA\Sentry\Reporter\RecursionAwareReporter;
+use OCP\Support\CrashReport\ICollectBreadcrumbs;
+use OCP\Support\CrashReport\IMessageReporter;
+use OCP\Support\CrashReport\IReporter;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class RecursionAwareReporterTest extends TestCase {
+
+	/** @var RecursionAwareReporter */
+	private $reporter;
+
+	/** @var MockObject|IReporter|IMessageReporter|ICollectBreadcrumbs */
+	private $inner;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->inner = $this->createMock(IReporter::class);
+
+		$this->reporter = new RecursionAwareReporter(
+			$this->inner
+		);
+	}
+
+	public function testCollectRecursively(): void {
+		$user = null;
+		$this->inner
+			->expects($this->once())
+			->method('report')
+			->willReturnCallback(function () {
+				$this->reporter->report(new Exception('ex2'));
+			});
+		$this->reporter->report(new Exception('ex1'));
+	}
+
+}

--- a/tests/Unit/Reporter/SentryReporterAdapterTest.php
+++ b/tests/Unit/Reporter/SentryReporterAdapterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2020 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Tests\Unit\Reporter;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use Exception;
+use OCA\Sentry\Reporter\SentryReporterAdapter;
+
+class SentryReporterAdapterTest extends TestCase {
+
+	/** @var ServiceMockObject */
+	private $serviceMock;
+
+	/** @var SentryReporterAdapter */
+	private $adapter;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->serviceMock = $this->createServiceMock(SentryReporterAdapter::class);
+		$this->adapter = $this->serviceMock->getService();
+	}
+
+	public function testReportAnonymously(): void {
+		$user = null;
+		$this->serviceMock->getParameter('userSession')
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->adapter->report(new Exception());
+	}
+
+	public function testCollectAnonymously(): void {
+		$user = null;
+		$this->serviceMock->getParameter('userSession')
+			->expects($this->once())
+			->method('getUser')
+			->willReturn($user);
+		$this->adapter->collect('msg 1', 'log');
+	}
+
+}


### PR DESCRIPTION
Add a decorator that keeps book about a currently ongoing report and
ignores any further method calls when that is the case.

Fixes #121 