### PR TITLE
Update CSP sentry doc url

### DIFF
--- a/doc/admin.md
+++ b/doc/admin.md
@@ -20,7 +20,7 @@ If you omit the `sentry.public-dsn` config, client-side (browser) errors won't b
 
 ### CSP error reporting
 
-[Sentry can capture CSP violation reports](https://docs.sentry.io/error-reporting/security-policy-reporting/). Just set the `sentry.csp-report-url` in addition to your other configuration parameters:
+[Sentry can capture CSP violation reports](https://docs.sentry.io/product/security-policy-reporting/). Just set the `sentry.csp-report-url` in addition to your other configuration parameters:
 
 ```
   "sentry.dsn" => "https://xxxxx:yyyyy@sentry.io/1234567",


### PR DESCRIPTION
The new url is working: https://docs.sentry.io/product/security-policy-reporting/