### PR TITLE
chore(deps): Create conventional commits for production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,40 @@ updates:
   commit-message:
     prefix: "chore"
     include: "scope"
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "02:00"
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "fix"
+    include: "scope"
+  ignore:
+    - dependency-type: production
+      update-types: [ "version-update:semver-major" ]
+    - dependency-type: production
+      update-types: [ "version-update:semver-minor" ]
+  allow:
+    - dependency-type: production
+      update-types: [ "version-update:semver-patch" ]
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "02:00"
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "feat"
+    include: "scope"
+  ignore:
+    - dependency-type: production
+      update-types: [ "version-update:semver-patch" ]
+  allow:
+    - dependency-type: production
+      update-types: [ "version-update:semver-major" ]
+    - dependency-type: production
+      update-types: [ "version-update:semver-minor" ]
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -18,3 +52,39 @@ updates:
   commit-message:
     prefix: "chore"
     include: "scope"
+  ignore:
+    - dependency-type: production
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "02:00"
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "fix"
+    include: "scope"
+  ignore:
+    - dependency-type: production
+      update-types: [ "version-update:semver-major" ]
+    - dependency-type: production
+      update-types: [ "version-update:semver-minor" ]
+  allow:
+    - dependency-type: production
+      update-types: [ "version-update:semver-patch" ]
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "02:00"
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "feat"
+    include: "scope"
+  ignore:
+    - dependency-type: production
+      update-types: [ "version-update:semver-patch" ]
+  allow:
+    - dependency-type: production
+      update-types: [ "version-update:semver-major" ]
+    - dependency-type: production
+      update-types: [ "version-update:semver-minor" ]


### PR DESCRIPTION
dev dep -> chore -> no release
prod dep patch -> fix -> patch release
prod dep minor/major -> feat -> minor release

Background: I want a patch release when `@sentry/*` gets a patch update and a minor release for every minor/major update of it.