### PR TITLE
fix(deps): Do not ship PSR packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,12 @@
 		"roave/security-advisories": "dev-master",
 		"psalm/phar": "^5.7.0"
 	},
+	"provide": {
+		"psr/clock": "*",
+		"psr/container": "*",
+		"psr/event-dispatcher": "*",
+		"psr/log": "*"
+	},
 	"scripts": {
 		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",
 		"psalm": "psalm.phar",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f19bfd341019209496cb4ec85dcb842",
+    "content-hash": "f8ae2912d3a93dfa45e279a500ae7999",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1028,56 +1028,6 @@
                 "source": "https://github.com/php-fig/http-message/tree/master"
             },
             "time": "2016-08-06T14:39:51+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
-            },
-            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "ralouphie/getallheaders",


### PR DESCRIPTION
clock, container and event-dispatcher are provided by Nextcloud

Ref https://github.com/nextcloud/3rdparty/blob/0ec73636ee36558960a1df60828b645ef3d4a53c/composer.json#L45-L47

This is not a very sophisticated solution. This info might get out of sync quickly. And I don't know how well Composer resolves dependencies with the `*` notation.

Ideally we had a meta package for official, global Nextcloud dependencies like the PSR family that apps can require to prevent the double installation.

Fixes https://github.com/ChristophWurst/nextcloud_sentry/issues/517