### PR TITLE
fix(config): cast config returned by getSystemValue to float as the function return type expects

### DIFF
--- a/lib/Config.php
+++ b/lib/Config.php
@@ -70,7 +70,7 @@ class Config {
 	public function getSamplingRate(): float {
 		$fromConfig = $this->config->getSystemValue('sentry.sampling-rate', null);
 		if ($fromConfig !== null) {
-			return $fromConfig;
+			return (float) $fromConfig;
 		}
 
 		return match ($this->config->getSystemValueInt('loglevel', 2)) {


### PR DESCRIPTION
Fixes: `OCA\Sentry\Config::getSamplingRate(): Return value must be of type float, string returned`