### PR TITLE
feat: Add profiles_sample_rate

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -74,6 +74,7 @@ class Application extends App implements IBootstrap {
 					'dsn' => $dsn,
 					'release' => $config->getServerVersion(),
 					'traces_sample_rate' => $config->getSamplingRate(),
+					'profiles_sample_rate' => $config->getProfilesSamplingRate(),
 				]);
 			}
 		});

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -82,4 +82,18 @@ class Config {
 		};
 	}
 
+	public function getProfilesSamplingRate(): float {
+		$fromConfig = $this->config->getSystemValue('sentry.profiles-sampling-rate', null);
+		if ($fromConfig !== null) {
+			return $fromConfig;
+		}
+
+		return match ($this->config->getSystemValueInt('loglevel', 2)) {
+			0 => 1.0,
+			1 => 0.7,
+			2 => 0.3,
+			3 => 0.2,
+			default => 0.1,
+		};
+	}
 }


### PR DESCRIPTION
To make use of https://docs.sentry.io/platforms/php/profiling/

I've been running that for quite a while on my personal instance and seems quite nice to get some more insights, though I haven't been extensively using the results yet (as I forgot I had deployed that 🙈 )

<img width="1455" alt="Screenshot 2023-12-28 at 11 36 30" src="https://github.com/ChristophWurst/nextcloud_sentry/assets/3404133/b0f31c96-65f5-47ba-a9c0-3bf7e5b8546e">
