### PR TITLE
Add support for environment config parameter

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -75,7 +75,7 @@ class Application extends App implements IBootstrap {
 					'release' => $config->getServerVersion(),
 					'traces_sample_rate' => $config->getSamplingRate(),
 					'profiles_sample_rate' => $config->getProfilesSamplingRate(),
-                    'environment' => $config->getEnvironment(),
+					'environment' => $config->getEnvironment(),
 				]);
 			}
 		});

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -75,6 +75,7 @@ class Application extends App implements IBootstrap {
 					'release' => $config->getServerVersion(),
 					'traces_sample_rate' => $config->getSamplingRate(),
 					'profiles_sample_rate' => $config->getProfilesSamplingRate(),
+                    'environment' => $config->getEnvironment(),
 				]);
 			}
 		});

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -96,4 +96,8 @@ class Config {
 			default => 0.1,
 		};
 	}
+
+    public function getEnvironment(): string {
+        return $this->config->getSystemValue('sentry.environment', 'production');
+    }
 }

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -97,7 +97,7 @@ class Config {
 		};
 	}
 
-    public function getEnvironment(): string {
-        return $this->config->getSystemValue('sentry.environment', 'production');
-    }
+	public function getEnvironment(): string {
+		return $this->config->getSystemValue('sentry.environment', 'production');
+	}
 }


### PR DESCRIPTION
This will allow users to set the Sentry environment using `sentry.environment`. I need this feature because of a pre-production environment.