### PR TITLE
fix: Do not ship psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
 		"sentry/sentry": "^3.22.1",
 		"guzzlehttp/promises": "^1.5.3"
 	},
+	"provide": {
+		"psr/log": "^1.0.4|^2|^3"
+	},
 	"require-dev": {
 		"christophwurst/nextcloud_testing": "^1.0.0",
 		"roave/security-advisories": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd54614f415674ee0df53a4e751e479f",
+    "content-hash": "0453ec57a997956eb527aee66d774c01",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -892,56 +892,6 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
-            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "sentry/sentry",


### PR DESCRIPTION
This should make the app compatible with psr/log v1 (29 and older), https://github.com/nextcloud-deps/ocp/pull/27 and https://github.com/nextcloud-deps/ocp/pull/26.

I'm telling composer that this package (the app) *provides* the psr/log packages, which prevents installation.