### PR TITLE
feat: capture whole error objects

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -28,6 +28,17 @@ import { loadState } from '@nextcloud/initial-state'
 
 import Logger from './logger'
 
+const attachErrorIntegration = {
+	name: 'AttachErrorIntegration',
+	processEvent(event, hint, client) {
+		if (hint.originalException) {
+			event.extra ??= {}
+			event.extra['error'] = hint.originalException
+		}
+		return event
+	},
+}
+
 try {
 	const dsn = loadState('sentry', 'dsn')
 
@@ -36,6 +47,9 @@ try {
 	} else {
 		const config = {
 			dsn,
+			integrations: [
+				attachErrorIntegration,
+			],
 		}
 
 		if (typeof OC.config.version !== 'undefined') {


### PR DESCRIPTION
Capture the whole error object and send it to Sentry to get more debugging data. Some exceptions/errors are enriched with properties which are not contained in the message. Currently, the extra data is lost completely, as Sentry only records the message by default.