### PR TITLE
fix: don't send http request body by default

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -76,6 +76,7 @@ class Application extends App implements IBootstrap {
 					'traces_sample_rate' => $config->getSamplingRate(),
 					'profiles_sample_rate' => $config->getProfilesSamplingRate(),
 					'environment' => $config->getEnvironment(),
+					'max_request_body_size' => $config->getMaxRequestBodySize(),
 				]);
 			}
 		});

--- a/lib/Config.php
+++ b/lib/Config.php
@@ -106,4 +106,8 @@ class Config {
 	public function getEnvironment(): string {
 		return $this->config->getSystemValueString('sentry.environment', 'production');
 	}
+
+	public function getMaxRequestBodySize(): string {
+		return $this->config->getSystemValueString('sentry.max-request-body-size', 'never');
+	}
 }

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -242,4 +242,26 @@ class ConfigTest extends TestCase {
 
 		self::assertSame('staging', $result);
 	}
+
+	public function testGetMaxRequestBodySizeReturnsDefault(): void {
+		$this->nextcloudConfig
+			->method('getSystemValueString')
+			->with('sentry.max-request-body-size', 'never')
+			->willReturn('never');
+
+		$result = $this->config->getMaxRequestBodySize();
+
+		self::assertSame('never', $result);
+	}
+
+	public function testGetMaxRequestBodySizeReturnsConfigured(): void {
+		$this->nextcloudConfig
+			->method('getSystemValueString')
+			->with('sentry.max-request-body-size', 'never')
+			->willReturn('medium');
+
+		$result = $this->config->getMaxRequestBodySize();
+
+		self::assertSame('medium', $result);
+	}
 }


### PR DESCRIPTION
It can contain sensitive data. Admins can still opt-in to have it sent.

Fixes https://github.com/ChristophWurst/nextcloud_sentry/issues/801